### PR TITLE
Ajoute des cas à PATTERN_OPEN_ACCESS

### DIFF
--- a/src/transform.py
+++ b/src/transform.py
@@ -6,7 +6,12 @@ load_dotenv()
 
 PATTERN_OPEN_ACCESS = [
     "pas de restriction d'accès public selon inspire",
+    "pas de restriction d’accès public selon inspire",
+    "pas de restriction d’accès publique",
+    "pas de restriction d'accès publique",
     "licence ouverte",
+    "pas de restriction d'accès au public",
+    "directive 2007/2/ce (inspire), pas de restriction d'accès public",
     "open licence",
 ]
 

--- a/src/transform.py
+++ b/src/transform.py
@@ -13,6 +13,7 @@ PATTERN_OPEN_ACCESS = [
     "pas de restriction d'accès au public",
     "directive 2007/2/ce (inspire), pas de restriction d'accès public",
     "open licence",
+    "ces données sont réutilisables sans restriction par le public",
 ]
 
 


### PR DESCRIPTION
En cherchant à identifier les données non ouvertes, je suis tombé sur de nouvelles valeurs de `right_statement` à traiter comme ouverts.